### PR TITLE
Fix deprecated tree_map

### DIFF
--- a/mctx/_src/policies.py
+++ b/mctx/_src/policies.py
@@ -477,9 +477,9 @@ def _make_stochastic_recurrent_fn(
           expanded_is_decision,
           decision_leaf, chance_leaf)
 
-    output = jax.tree.map(_broadcast_where,
-                          output_if_decision_node,
-                          output_if_chance_node)
+    output = jax.tree_util.tree_map(_broadcast_where,
+                                    output_if_decision_node,
+                                    output_if_chance_node)
     return output, new_state
 
   return stochastic_recurrent_fn


### PR DESCRIPTION
Deprecations & Removals

jax.tree_map() is deprecated; use jax.tree.map instead, or for backward compatibility with older JAX versions, use [jax.tree_util.tree_map()](https://docs.jax.dev/en/latest/_autosummary/jax.tree_util.tree_map.html#jax.tree_util.tree_map).